### PR TITLE
fix(dotnet): add mising public API for ExecWinPsParams

### DIFF
--- a/dotnet/Devolutions.NowClient/Devolutions.NowClient.csproj
+++ b/dotnet/Devolutions.NowClient/Devolutions.NowClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Devolutions.NowClient</PackageId>
-    <Version>2025.9.4.0</Version>
+    <Version>2025.9.4.1</Version>
 
     <Authors>Devolutions Inc.</Authors>
     <Company>Devolutions Inc.</Company>

--- a/dotnet/Devolutions.NowClient/src/ExecWinPsParams.cs
+++ b/dotnet/Devolutions.NowClient/src/ExecWinPsParams.cs
@@ -85,7 +85,7 @@ namespace Devolutions.NowClient
         /// Enables or disables the use of pipes for standard input, output, and error streams.
         /// When enabled, the process's standard streams are redirected through pipes.
         /// </summary>
-        private ExecWinPsParams IoRedirection(bool enable = true)
+        public ExecWinPsParams IoRedirection(bool enable = true)
         {
             _ioRedirection = enable;
             return this;


### PR DESCRIPTION
For some strange reason, I accidentally marked `IoRedirection` param for `ExecWinPsParams` as private 🤦 

cc @CBenoit, please trigger dotnet release after merge 🙏 