### PR TITLE
add dynamic nuget versioning

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -3,6 +3,10 @@ name: Publish libraries
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'release version'
+        default: "latest"
+        required: true
       dry-run:
         description: 'Dry run'
         required: true
@@ -16,27 +20,37 @@ jobs:
     name: Preflight
     runs-on: ubuntu-latest
     outputs:
-      dry-run: ${{ steps.get-dry-run.outputs.dry-run }}
+      package-version: ${{ steps.info.outputs.package-version }}
+      dry-run: ${{ steps.info.outputs.dry-run }}
 
     steps:
-      - name: Get dry run
-        id: get-dry-run
+      - name: Package information
+        id: info
         shell: pwsh
         run: |
           Set-PSDebug -Trace 1
 
-          $IsDryRun = '${{ github.event.inputs.dry-run }}' -Eq 'true' -Or '${{ github.event_name }}' -Eq 'schedule'
+          try { $DryRun = [System.Boolean]::Parse('${{ inputs.dry-run }}') } catch { $DryRun = $true }
 
-          if ($IsDryRun) {
-            echo "dry-run=true" >> $Env:GITHUB_OUTPUT
-          } else {
-            echo "dry-run=false" >> $Env:GITHUB_OUTPUT
+          $PackageVersion = '${{ inputs.version }}'
+          if ([string]::IsNullOrEmpty($PackageVersion) -or $PackageVersion -eq 'latest') {
+            $PackageVersion = (Get-Date -Format "yyyy.MM.dd") + ".0"
           }
+
+          if ($PackageVersion -NotMatch '^\d+\.\d+\.\d+\.\d+$') {
+            throw "invalid version format: $PackageVersion, expected: 1.2.3.4"
+          }
+
+          echo "package-version=$PackageVersion" >> $Env:GITHUB_OUTPUT
+          echo "dry-run=$($DryRun.ToString().ToLower())" >> $Env:GITHUB_OUTPUT
+
+          echo "::notice::Version: $PackageVersion"
+          echo "::notice::DryRun: $DryRun"
 
   build:
     name: NuGet package build [${{matrix.library}}]
     runs-on: windows-2022
-
+    needs: [preflight]
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +62,18 @@ jobs:
     steps:
       - name: Check out ${{ github.repository }}
         uses: actions/checkout@v4
+
+      - name: Set package version
+        shell: pwsh
+        run: |
+          $PackageVersion = '${{ needs.preflight.outputs.package-version }}'
+          @("dotnet\Devolutions.NowClient\Devolutions.NowClient.csproj",
+            "dotnet\Devolutions.NowProto\Devolutions.NowProto.csproj") | ForEach-Object {
+            $csprojPath = $_
+            $csprojContent = Get-Content $csprojPath -Raw
+            $csprojContent = $csprojContent -Replace '(<Version>).*?(</Version>)', "<Version>$PackageVersion</Version>"
+            Set-Content -Path $csprojPath -Value $csprojContent -Encoding UTF8
+          }
 
       - name: Build
         shell: pwsh
@@ -75,7 +101,7 @@ jobs:
   merge:
     name: NuGet merge artifacts
     runs-on: ubuntu-latest
-    needs: build
+    needs: [preflight, build]
 
     steps:
       - name: Merge Artifacts

--- a/dotnet/Devolutions.NowClient/Devolutions.NowClient.csproj
+++ b/dotnet/Devolutions.NowClient/Devolutions.NowClient.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Devolutions.NowClient</PackageId>
-    <Version>2025.9.4.1</Version>
-
+    <Version>1.0.0.0</Version>
     <Authors>Devolutions Inc.</Authors>
     <Company>Devolutions Inc.</Company>
     <AssemblyTitle>Async client for the NOW protocol</AssemblyTitle>

--- a/dotnet/Devolutions.NowProto/Devolutions.NowProto.csproj
+++ b/dotnet/Devolutions.NowProto/Devolutions.NowProto.csproj
@@ -1,6 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageId>Devolutions.NowProto</PackageId>
+    <Version>1.0.0.0</Version>
+    <AssemblyTitle>Core NOW protocol library</AssemblyTitle>
+    <Copyright>© Devolutions Inc. All rights reserved.</Copyright>
+    <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Devolutions/now-proto.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Add dynamic nuget versioning. Assemblies are set to 1.0.0.0 in git, and the workflow replaces it with a dynamic version based on today's date, or accepts an explicit version number. The workflow should handle scheduled builds as well. Both Devolutions.NowProto.dll and Devolutions.NowClient.dll now have proper version info. I'll make a new release after this is merged just so we have a nuget package with correct version info in RDM.