### PR TITLE
Rename .NET policy model package

### DIFF
--- a/policies/README.md
+++ b/policies/README.md
@@ -3,4 +3,4 @@ Policies
 
 This directory contains Devolutions Agent NOW policy libraries.
 
-The .NET package is published as `Devolutions.NowPolicy`, and the Rust crate is published as `now-policy`.
+The .NET policy model package is published as `Devolutions.Now.Policy.Model`, and the Rust crate is published as `now-policy`.

--- a/policies/dotnet/Devolutions.Now.Policy.Model.Tests/Devolutions.Now.Policy.Model.Tests.csproj
+++ b/policies/dotnet/Devolutions.Now.Policy.Model.Tests/Devolutions.Now.Policy.Model.Tests.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <RootNamespace>Devolutions.NowPolicy.Tests</RootNamespace>
+    <RootNamespace>Devolutions.Now.Policy.Model.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Devolutions.NowPolicy/Devolutions.NowPolicy.csproj" />
+    <ProjectReference Include="../Devolutions.Now.Policy.Model/Devolutions.Now.Policy.Model.csproj" />
   </ItemGroup>
 
 </Project>

--- a/policies/dotnet/Devolutions.Now.Policy.Model.Tests/PolicyTests.cs
+++ b/policies/dotnet/Devolutions.Now.Policy.Model.Tests/PolicyTests.cs
@@ -5,7 +5,7 @@ using NJsonSchema;
 
 using Xunit;
 
-namespace Devolutions.NowPolicy.Tests;
+namespace Devolutions.Now.Policy.Model.Tests;
 
 public class PolicyTests
 {

--- a/policies/dotnet/Devolutions.Now.Policy.Model/Devolutions.Now.Policy.Model.csproj
+++ b/policies/dotnet/Devolutions.Now.Policy.Model/Devolutions.Now.Policy.Model.csproj
@@ -4,16 +4,16 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>Devolutions.NowPolicy</RootNamespace>
-    <AssemblyName>Devolutions.NowPolicy</AssemblyName>
+    <RootNamespace>Devolutions.Now.Policy.Model</RootNamespace>
+    <AssemblyName>Devolutions.Now.Policy.Model</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>Devolutions.NowPolicy</PackageId>
+    <PackageId>Devolutions.Now.Policy.Model</PackageId>
     <Version>0.0.0.0</Version>
     <AssemblyTitle>Devolutions NOW policy model</AssemblyTitle>
-    <Description>Policy creation and parsing APIs for Devolutions Agent NOW policy documents.</Description>
+    <Description>Policy document model, creation, and parsing APIs for Devolutions Agent NOW policies.</Description>
     <Authors>Devolutions Inc.</Authors>
     <Copyright>© Devolutions Inc. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>

--- a/policies/dotnet/Devolutions.Now.Policy.Model/Enums.cs
+++ b/policies/dotnet/Devolutions.Now.Policy.Model/Enums.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace Devolutions.NowPolicy;
+namespace Devolutions.Now.Policy.Model;
 
 /// <summary>Package operation type.</summary>
 [JsonConverter(typeof(JsonStringEnumConverter<Operation>))]

--- a/policies/dotnet/Devolutions.Now.Policy.Model/PolicyJson.cs
+++ b/policies/dotnet/Devolutions.Now.Policy.Model/PolicyJson.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Devolutions.NowPolicy;
+namespace Devolutions.Now.Policy.Model;
 
 public static class PolicyJson
 {

--- a/policies/dotnet/Devolutions.Now.Policy.Model/PolicyModels.cs
+++ b/policies/dotnet/Devolutions.Now.Policy.Model/PolicyModels.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 
-namespace Devolutions.NowPolicy;
+namespace Devolutions.Now.Policy.Model;
 
 public static class SchemaUris
 {

--- a/policies/dotnet/Devolutions.Now.Policy.slnx
+++ b/policies/dotnet/Devolutions.Now.Policy.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="Devolutions.Now.Policy.Model.Tests/Devolutions.Now.Policy.Model.Tests.csproj"/>
+  <Project Path="Devolutions.Now.Policy.Model/Devolutions.Now.Policy.Model.csproj"/>
+</Solution>

--- a/policies/dotnet/Devolutions.NowPolicy.slnx
+++ b/policies/dotnet/Devolutions.NowPolicy.slnx
@@ -1,4 +1,0 @@
-<Solution>
-  <Project Path="Devolutions.NowPolicy.Tests/Devolutions.NowPolicy.Tests.csproj"/>
-  <Project Path="Devolutions.NowPolicy/Devolutions.NowPolicy.csproj"/>
-</Solution>

--- a/policies/dotnet/README.md
+++ b/policies/dotnet/README.md
@@ -1,4 +1,4 @@
-Devolutions NOW policy
-======================
+Devolutions NOW policy model
+============================
 
-This package provides .NET types and JSON/YAML parsing helpers for Devolutions Agent NOW policy documents.
+This package provides .NET policy document model types and JSON/YAML parsing helpers for Devolutions Agent NOW policies.

--- a/xtask/src/dotnet.rs
+++ b/xtask/src/dotnet.rs
@@ -17,8 +17,8 @@ const SOLUTIONS: &[DotnetSolution] = &[
         set_platform: true,
     },
     DotnetSolution {
-        path: "policies/dotnet/Devolutions.NowPolicy.slnx",
-        artifact_project: "policies/dotnet/Devolutions.NowPolicy",
+        path: "policies/dotnet/Devolutions.Now.Policy.slnx",
+        artifact_project: "policies/dotnet/Devolutions.Now.Policy.Model",
         set_platform: false,
     },
 ];


### PR DESCRIPTION
## Summary
- Rename the existing .NET policy package from `Devolutions.NowPolicy` to `Devolutions.Now.Policy.Model`.
- Rename the .NET policy solution, project folders, project files, namespaces, and test project to match the new package identity.
- Update policy README wording to describe the .NET policy model package.
- Update `xtask` so formatting/build/test automation uses the renamed policy solution and project paths.

## Policy NuGet Naming

This PR starts the policy package family under the `Devolutions.Now.Policy.*` namespace. The intent is for packages under `policies/` to cover policy-related code broadly, not only the current package-operation policy document shape.

Proposed policy NuGet roles:

| Package | Role |
| --- | --- |
| `Devolutions.Now.Policy.Model` | Admin-authored policy documents and schema-facing model types: policy documents, metadata, rules, constraints, parsing, serialization, and schema helpers. This is the package renamed in this PR. |
| `Devolutions.Now.Policy.Api` | Future Agent policy API boundary types: requests, responses, decision payloads, errors, capabilities, and versioning. This keeps API shapes separate from policy document models without introducing a second `.Model` package. |
| `Devolutions.Now.Policy.Client` | Future client implementation that talks to the Agent policy API and depends on `Devolutions.Now.Policy.Api`. |

This keeps the naming centered on policy as the umbrella domain while reserving `.Model` specifically for admin-authored policy document models.

## Tests
- `dotnet format .\policies\dotnet\Devolutions.Now.Policy.slnx --verify-no-changes`
- `dotnet test .\policies\dotnet\Devolutions.Now.Policy.slnx`